### PR TITLE
line-height を調整し、改行した際にピンインと漢字が重ならないようにした

### DIFF
--- a/src/style.css.ts
+++ b/src/style.css.ts
@@ -18,13 +18,13 @@ export const container = style({
 export const chineseCharLine = style({
     position: 'relative',
     overflowWrap: 'anywhere',
-    lineHeight: '2rem',
+    lineHeight: '2.7rem',
 });
 
 export const pinyinLine = style({
     position: 'absolute',
     overflowWrap: 'anywhere',
-    lineHeight: '2rem',
+    lineHeight: '2.7rem',
     marginTop: '-1.3rem',
     userSelect: 'none',
     fontSize: '0.8rem',


### PR DESCRIPTION
| 変更前 | 変更後 |
| --- | --- |
| ![スクリーンショット 2023-11-12 164706](https://github.com/0918nobita/obsidian-zhongwen-block/assets/8453302/f1ab5bbf-91e2-4def-9ee8-1752b5ea83be) | ![スクリーンショット 2023-11-12 164801](https://github.com/0918nobita/obsidian-zhongwen-block/assets/8453302/0f2aee4c-3e24-4188-8ded-32bc9176a9c1) |
