### PR TITLE
Fix a display bug in Live Preview mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "zhongwen-block",
     "name": "Zhongwen Block",
-    "version": "0.3.0",
+    "version": "0.3.1-beta",
     "minAppVersion": "0.15.0",
     "description": "Provides code blocks with features for Chinese learners",
     "author": "Kodai Matsumoto",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": "true",
     "name": "@0918nobita/obsidian-zhongwen-block",
-    "version": "0.3.0",
+    "version": "0.3.1-beta",
     "description": "An Obsidian plugin which provides code blocks with features for Chinese learners",
     "scripts": {
         "build": "vite build",

--- a/src/style.css.ts
+++ b/src/style.css.ts
@@ -2,6 +2,11 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
     position: 'relative',
+    selectors: {
+        [`.cm-preview-code-block &`]: {
+            marginTop: '0.5rem',
+        },
+    },
 });
 
 export const chineseCharLine = style({


### PR DESCRIPTION
Fixes #16 

In Live Preview mode, unlike Reading View, overflowing contents of code blocks are not visible.
This happens due to the behavior of Code Mirror v6.

Specifically, in Live Preview mode, the content rendered for a code block is wrapped in `div.cm-preview-code-block` .
`div.cm-preview-code-block` contains following CSS property:
```css
contain: paint;
```
> Descendants of the element don't display outside its bounds.
> https://developer.mozilla.org/en-US/docs/Web/CSS/contain#paint

So I fixed this display bug by applying `padding-top` to the root element of code block only in Live Preview mode.

## Screenshots (in Live Preview mode)

| Before | After |
| --- | --- |
| <img width="1002" alt="スクリーンショット 2023-11-26 17 40 51" src="https://github.com/0918nobita/obsidian-zhongwen-block/assets/8453302/2dcdff59-89ab-47e6-8d35-9cec778b2c28"> | <img width="1003" alt="スクリーンショット 2023-11-26 17 39 25" src="https://github.com/0918nobita/obsidian-zhongwen-block/assets/8453302/9ee99cd8-32ef-4d2d-8220-ef1b751865cc"> |
