### PR TITLE
HTML 文書の読み込みを待機する部分を修正

### DIFF
--- a/src/code-block-processor.ts
+++ b/src/code-block-processor.ts
@@ -4,18 +4,14 @@ import type { Settings } from './settings';
 
 import * as styles from './style.css';
 
-export const codeBlockProcessor = async (
+export const codeBlockProcessor = (
     source: string,
     element: HTMLElement,
     settings: Settings,
-) => {
+): void => {
     const gap = 2;
 
     const pinyinData = pinyin(source, { type: 'all' });
-
-    await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-    });
 
     const container = element.createDiv({
         cls: styles.container,

--- a/src/plugin-impl.ts
+++ b/src/plugin-impl.ts
@@ -5,6 +5,17 @@ import type { Plugin } from './plugin';
 import { type Settings, defaultSettings } from './settings';
 import { SettingTabImpl } from './setting-tab-impl';
 
+const domReady = (): Promise<void> =>
+    new Promise((resolve) => {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => {
+                resolve();
+            });
+        } else {
+            resolve();
+        }
+    });
+
 export class PluginImpl extends Obsidian.Plugin implements Plugin {
     settings!: Settings;
 
@@ -14,13 +25,20 @@ export class PluginImpl extends Obsidian.Plugin implements Plugin {
             defaultSettings,
             (await this.loadData()) as Settings,
         );
+
         this.addSettingTab(new SettingTabImpl(this.app, this));
-        this.registerMarkdownCodeBlockProcessor('zh-cn', (source, element) =>
-            codeBlockProcessor(source, element, this.settings),
+
+        this.registerMarkdownCodeBlockProcessor(
+            'zh-cn',
+            async (source, element) => {
+                await domReady();
+
+                codeBlockProcessor(source, element, this.settings);
+            },
         );
     }
 
-    async saveSettings() {
+    async saveSettings(): Promise<void> {
         await this.saveData(this.settings);
     }
 }


### PR DESCRIPTION
`document.readyState` を参照して、必要があれば `DOMContentLoaded` イベントに対するハンドラを登録するようにした