### PR TITLE
:bug: 画面外の要素のレイアウトが崩れる不具合を修正した

### DIFF
--- a/src/code-block-processor.ts
+++ b/src/code-block-processor.ts
@@ -4,11 +4,28 @@ import type { Settings } from './settings';
 
 import * as styles from './style.css';
 
-export const codeBlockProcessor = (
+const waitAndMeasureCorrectWidth = (element: HTMLElement): Promise<number> =>
+    new Promise((resolve) => {
+        const observer = new IntersectionObserver((entries) => {
+            if (entries.length === 0) {
+                return;
+            }
+
+            const { width } = entries[0].boundingClientRect;
+            if (width !== 0) {
+                observer.disconnect();
+                resolve(width);
+            }
+        });
+
+        observer.observe(element);
+    });
+
+export const codeBlockProcessor = async (
     source: string,
     element: HTMLElement,
     settings: Settings,
-): void => {
+): Promise<void> => {
     const gap = 2;
 
     const pinyinData = pinyin(source, { type: 'all' });
@@ -23,8 +40,8 @@ export const codeBlockProcessor = (
             : styles.pinyinLineDisplayedOnHover,
     });
 
-    const chineseCharLine = container.createDiv({
-        cls: styles.chineseCharLine,
+    const zhCharLine = container.createDiv({
+        cls: styles.zhCharLine,
     });
 
     for (const pinyinDatum of pinyinData) {
@@ -32,30 +49,33 @@ export const codeBlockProcessor = (
             text: pinyinDatum.pinyin,
             cls: styles.pinyinSpan,
         });
-        const pinyinWidth = pinyinSpan.getBoundingClientRect().width;
 
-        const chineseCharSpan = chineseCharLine.createSpan({
+        let pinyinWidth = pinyinSpan.getBoundingClientRect().width;
+        if (pinyinDatum.pinyin !== '' && pinyinWidth === 0) {
+            pinyinWidth = await waitAndMeasureCorrectWidth(pinyinSpan);
+        }
+
+        const zhCharSpan = zhCharLine.createSpan({
             text: pinyinDatum.origin,
-            cls: styles.chineseCharSpan,
+            cls: styles.zhCharSpan,
         });
-        const chineseCharWidth = chineseCharSpan.getBoundingClientRect().width;
+        const zhCharWidth = zhCharSpan.getBoundingClientRect().width;
 
-        const { pinyinPadding, chineseCharPadding } =
-            pinyinWidth >= chineseCharWidth
+        const { pinyinPadding, zhCharPadding } =
+            pinyinWidth >= zhCharWidth
                 ? {
                       pinyinPadding: gap,
-                      chineseCharPadding:
-                          (pinyinWidth - chineseCharWidth) / 2 + gap,
+                      zhCharPadding: (pinyinWidth - zhCharWidth) / 2 + gap,
                   }
                 : {
-                      pinyinPadding: (chineseCharWidth - pinyinWidth) / 2 + gap,
-                      chineseCharPadding: gap,
+                      pinyinPadding: (zhCharWidth - pinyinWidth) / 2 + gap,
+                      zhCharPadding: gap,
                   };
 
         pinyinSpan.style.paddingLeft = `${pinyinPadding}px`;
         pinyinSpan.style.paddingRight = `${pinyinPadding}px`;
 
-        chineseCharSpan.style.paddingLeft = `${chineseCharPadding}px`;
-        chineseCharSpan.style.paddingRight = `${chineseCharPadding}px`;
+        zhCharSpan.style.paddingLeft = `${zhCharPadding}px`;
+        zhCharSpan.style.paddingRight = `${zhCharPadding}px`;
     }
 };

--- a/src/plugin-impl.ts
+++ b/src/plugin-impl.ts
@@ -33,7 +33,7 @@ export class PluginImpl extends Obsidian.Plugin implements Plugin {
             async (source, element) => {
                 await domReady();
 
-                codeBlockProcessor(source, element, this.settings);
+                await codeBlockProcessor(source, element, this.settings);
             },
         );
     }

--- a/src/style.css.ts
+++ b/src/style.css.ts
@@ -9,13 +9,13 @@ export const container = style({
     },
 });
 
-export const chineseCharLine = style({
+export const zhCharLine = style({
     position: 'relative',
     overflowWrap: 'anywhere',
     lineHeight: '2.7rem',
 });
 
-export const chineseCharSpan = style({
+export const zhCharSpan = style({
     display: 'inline-block',
 });
 
@@ -38,7 +38,7 @@ export const pinyinLineDisplayedOnHover = style([
         opacity: '0',
         transition: 'opacity .3s ease',
         selectors: {
-            [`${container}:has(> ${chineseCharLine}:hover) > &`]: {
+            [`${container}:has(> ${zhCharLine}:hover) > &`]: {
                 opacity: '1',
             },
         },


### PR DESCRIPTION
画面外の要素の描画は遅延されることがあり、その場合 `Element.getBoundingClientRect()` が正しくない値を返してしまうため、コードブロックプロセッサ側に IntersectionObserver を用いて正しい値が得られるまで待機する処理を追加した