### PR TITLE
:lipstick: Fix the styles of code block processor to display line breaks as they are

### DIFF
--- a/src/code-block-processor/style.css.ts
+++ b/src/code-block-processor/style.css.ts
@@ -28,6 +28,7 @@ export const hiddenZhChar = style({
 
 export const hiddenNonZh = style({
     opacity: '0',
+    whiteSpace: 'pre',
 });
 
 export const pinyin = {
@@ -59,4 +60,8 @@ export const zhCharLine = style({
 
 export const visibleZhBlock = style({
     display: 'inline-block',
+});
+
+export const visibleNonZhBlock = style({
+    whiteSpace: 'pre',
 });

--- a/src/code-block-processor/zh-char-line.ts
+++ b/src/code-block-processor/zh-char-line.ts
@@ -24,6 +24,9 @@ export class ZhCharLine {
     }
 
     appendNonZhSegment({ nonZhChars }: { nonZhChars: string }): void {
-        this.#el.appendText(nonZhChars);
+        this.#el.createSpan({
+            cls: styles.visibleNonZhBlock,
+            text: nonZhChars,
+        });
     }
 }


### PR DESCRIPTION
Fixes #75 